### PR TITLE
Fix target name in `binding.gyp`

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "tree_sitter_haskell_binding",
+      "target_name": "tree_sitter_purescript_binding",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "src"


### PR DESCRIPTION
This PR fixes the target name in `binding.gyp` to disambiguate the PureScript grammar from Haskell.

### Motivation

When building Zed on Linux we've been seeing some linking errors stemming from the PureScript Tree-sitter grammar.

I believe it is the collision between the `tree-sitter-haskell` and `tree-sitter-purescript` that is to blame.
